### PR TITLE
Add support for step size in Slider

### DIFF
--- a/src/PlutoUI.jl
+++ b/src/PlutoUI.jl
@@ -14,7 +14,7 @@ struct Slider
 end
 
 function show(io::IO, ::MIME"text/html", slider::Slider)
-    print(io, """<input type="range" min="$(slider.range.start)" max="$(slider.range.stop)" value="$(slider.range.start)">""")
+    print(io, """<input type="range" min="$(first(slider.range))" max="$(last(slider.range))" step="$(step(slider.range))" value="$(first(slider.range))">""")
 end
 
 peek(slider::Slider) = first(slider.range)


### PR DESCRIPTION
This changes Slider to be compatible with any `AbstractRange`. Especially those with a step size different to one.

For example this notebook now works:
```
### A Pluto.jl notebook ###
# v0.7.6

using Markdown
macro bind(def, element)
    quote
        local el = $(esc(element))
        global $(esc(def)) = Core.applicable(Base.peek, el) ? Base.peek(el) : missing
        el
    end
end
# ╔═╡ 5943255e-89e5-11ea-2218-c5f45d3b0cec
@bind a Slider(0:1)

# ╔═╡ 495fd708-89e6-11ea-0297-b1686e46d8c8
a

# ╔═╡ 934d5d2a-89e5-11ea-3cd9-7b085a60dcf6
@bind b Slider(0:0.1:1)

# ╔═╡ 4d59f016-89e6-11ea-1495-7f30c851983b
b

# ╔═╡ 54b8c4dc-89e5-11ea-03e6-631b2c46da82
using PlutoUI

# ╔═╡ Cell order:
# ╠═54b8c4dc-89e5-11ea-03e6-631b2c46da82
# ╠═5943255e-89e5-11ea-2218-c5f45d3b0cec
# ╠═495fd708-89e6-11ea-0297-b1686e46d8c8
# ╠═934d5d2a-89e5-11ea-3cd9-7b085a60dcf6
# ╠═4d59f016-89e6-11ea-1495-7f30c851983b
```