### PR TITLE
Restrict height of  result of with_terminal()

### DIFF
--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -16,6 +16,9 @@ div.PlutoUI_terminal pre {
     color: #ddd;
     background-color: transparent;
     margin-block-end: 0;
+    height: auto;
+    max-height: 400px;
+    overflow: auto;
 }
 div.PlutoUI_terminal pre.err {
     color: #ff5f5f;

--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -7,7 +7,7 @@ import Markdown: htmlesc
 const terminal_css = """
 <style>
 div.PlutoUI_terminal {
-    border: 5px solid pink;
+    border: 10px solid #cedbd0;
     border-radius: 12px;
     font-size: .65rem;
     background-color: #333;
@@ -17,9 +17,15 @@ div.PlutoUI_terminal pre {
     background-color: transparent;
     margin-block-end: 0;
     height: auto;
-    max-height: 400px;
+    max-height: 300px;
     overflow: auto;
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column-reverse;
+    white-space: pre-wrap;       
+    word-wrap: break-word;      
 }
+
 div.PlutoUI_terminal pre.err {
     color: #ff5f5f;
 }

--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -10,6 +10,7 @@ struct WithTerminalOutput
     stderr::String
     value::Any
 end
+
 function show(io::IO, mime::MIME"text/html", with_terminal::WithTerminalOutput)
 	show(io, mime, HTML("""
 		$(terminal_css)
@@ -96,4 +97,3 @@ function Dump(x; maxdepth=8)
 		dump(io, x; maxdepth=maxdepth)
 	end |> Text
 end
->>>>>>> master

--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -24,23 +24,20 @@ end
 const terminal_css = """
 <style>
 div.PlutoUI_terminal {
-    border: 10px solid #cedbd0;
-    border-radius: 12px;
+    border: 10px solid #cedbd0; /* https://www.vintagecomputer.net/browse_thread.cfm?id=618 */
+    border-radius: 15px;
     font-size: .65rem;
     background-color: #333;
+    max-height: 300px;
+    overflow: auto;
 }
 div.PlutoUI_terminal pre {
     color: #ddd;
     background-color: transparent;
     margin-block-end: 0;
     height: auto;
-    max-height: 300px;
-    overflow: auto;
-    display: flex;
-    flex-wrap: nowrap;
-    flex-direction: column-reverse;
-    white-space: pre-wrap;       
-    word-wrap: break-word;      
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 div.PlutoUI_terminal pre.err {


### PR DESCRIPTION
Hi, would be good to prevent the with_terminal() output from overflowing the screen...
Is it possible in css to set the scrollbar position to "completely down" ?