### PR TITLE
Adds support for microphone input

### DIFF
--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -1,12 +1,10 @@
 import Random: randstring
-<<<<<<< HEAD
 import Dates
 
 export Slider, NumberField, Button, CheckBox, TextField, PasswordField, Select, MultiSelect, Radio, FilePicker, DateField, TimeField, ColorStringPicker, Microphone
 =======
 
 export Slider, NumberField, Button, CheckBox, TextField, Select, FilePicker, Radio
->>>>>>> cd91008dfe913d18cecf9cf850743a8597b1224e
 
 struct Slider
     range::AbstractRange
@@ -154,7 +152,6 @@ end
 get(textfield::TextField) = textfield.default
 
 
-
 """A password input (`<input type="password">`) - the user can type text, the text is returned as `String` via `@bind`.
 
 This does not provide any special security measures, it just renders black dots (•••) instead of the typed characters.
@@ -202,7 +199,6 @@ Select(options::Array{<:Pair{<:AbstractString,<:Any},1}; default=missing) = Sele
 function show(io::IO, ::MIME"text/html", select::Select)
     withtag(io, :select) do
         for o in select.options
-<<<<<<< HEAD
             print(io, """<option value="$(htmlesc(o.first))"$(select.default === o.first ? " selected" : "")>""")
             if showable(MIME"text/html"(), o.second)
                 show(io, MIME"text/html"(), o.second)
@@ -246,7 +242,6 @@ function show(io::IO, ::MIME"text/html", select::MultiSelect)
                 show(io, MIME"text/html"(), o.second)
             else
                 print(io, o.second)
-=======
             print(io, """<option value="$(htmlesc(o.first))"$(radio.default === o.first ? " selected" : "")>""")
             withtag(io, :option, :value=>o.first) do
                 if showable(MIME"text/html"(), o.second)
@@ -254,14 +249,12 @@ function show(io::IO, ::MIME"text/html", select::MultiSelect)
                 else
                     print(io, o.second)
                 end
->>>>>>> cd91008dfe913d18cecf9cf850743a8597b1224e
             end
             print(io, "</option>")
         end
     end
 end
 
-<<<<<<< HEAD
 get(select::MultiSelect) = ismissing(select.default) ? Any[] : select.default
 
 """A file upload box. The chosen file will be read by the browser, and the bytes are sent back to Julia.
@@ -271,7 +264,6 @@ The optional `accept` argument can be an array of `MIME`s. The user can only sel
 ## Examples
 =======
 get(select::Select) = ismissing(select.default) ? first(select.options).first : select.default
->>>>>>> cd91008dfe913d18cecf9cf850743a8597b1224e
 
 `@bind file_data FilePicker()`
 
@@ -296,11 +288,9 @@ function show(io::IO, ::MIME"text/html", filepicker::FilePicker)
     print(io, "'>")
 end
 
-<<<<<<< HEAD
 get(select::FilePicker) = Dict("name" => "", "data" => UInt8[], "type" => "")
 =======
 get(select::FilePicker) = Dict("name" => "", "data" => [], "type" => "")
->>>>>>> cd91008dfe913d18cecf9cf850743a8597b1224e
 
 """A group of radio buttons - the user can choose one of the `options`, an array of `String`s. 
 
@@ -358,7 +348,6 @@ function show(io::IO, ::MIME"text/html", radio::Radio)
 end
 
 get(radio::Radio) = radio.default
-<<<<<<< HEAD
 
 struct Microphone end
 
@@ -487,5 +476,3 @@ function show(io::IO, ::MIME"text/html", colorStringPicker::ColorStringPicker)
     withtag(() -> (), io, :input, :type=>"color", :value=>colorStringPicker.default)
 end
 get(colorStringPicker::ColorStringPicker) = colorStringPicker.default
-=======
->>>>>>> cd91008dfe913d18cecf9cf850743a8597b1224e

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -1,7 +1,7 @@
 import Random: randstring
 import Dates
 
-export Slider, NumberField, Button, CheckBox, TextField, PasswordField, Select, MultiSelect, Radio, FilePicker, DateField, TimeField, ColorStringPicker
+export Slider, NumberField, Button, CheckBox, TextField, PasswordField, Select, MultiSelect, Radio, FilePicker, DateField, TimeField, ColorStringPicker, Microphone
 
 struct Slider
     range::AbstractRange
@@ -335,6 +335,74 @@ function show(io::IO, ::MIME"text/html", radio::Radio)
 end
 
 get(radio::Radio) = radio.default
+
+struct Microphone end
+
+function show(io::IO, ::MIME"text/html", microphone::Microphone)
+    mic_id = randstring('a':'z')
+    mic_btn_id = randstring('a':'z')
+    microphone
+    withtag(() -> (), io, :audio, :id => mic_id)
+    print(io, """<input type="button" id="$mic_btn_id" class="mic-button" value="Stop">""")
+    withtag(io, :script) do 
+        print(io, """
+            const player = document.getElementById('$mic_id');
+            const stop = document.getElementById('$mic_btn_id');
+        
+            const handleSuccess = function(stream) {
+            const context = new AudioContext({ sampleRate: 44100 });
+            const analyser = context.createAnalyser();
+            const source = context.createMediaStreamSource(stream);
+        
+            source.connect(analyser);
+            
+            const bufferLength = analyser.frequencyBinCount;
+            
+            let dataArray = new Float32Array(bufferLength);
+            let animFrame;
+            
+            const streamAudio = () => {
+                animFrame = requestAnimationFrame(streamAudio);
+                analyser.getFloatTimeDomainData(dataArray);
+                player.value = dataArray;
+                player.dispatchEvent(new CustomEvent("input"));
+            }
+        
+            streamAudio();
+        
+            stop.onclick = e => {
+                source.disconnect(analyser);
+                cancelAnimationFrame(animFrame);
+            }
+            }
+        
+            navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+            .then(handleSuccess)
+        """
+        )
+    end
+    withtag(io, :style) do 
+        print(io, """
+            .mic-button {
+                background-color: darkred;
+                border: none;
+                border-radius: 6px;
+                color: white;
+                padding: 15px 32px;
+                text-align: center;
+                text-decoration: none;
+                display: inline-block;
+                font-size: 16px;
+                font-family: "Alegreya Sans", sans-serif;
+                margin: 4px 2px;
+                cursor: pointer;
+            }
+        """
+        )
+    end
+end
+
+get(microphone::Microphone) = microphone
 
 """A date input (`<input type="date">`) - the user can pick a date, the date is returned as `Dates.DateTime` via `@bind`.
 

--- a/src/Builtins.jl
+++ b/src/Builtins.jl
@@ -2,9 +2,6 @@ import Random: randstring
 import Dates
 
 export Slider, NumberField, Button, CheckBox, TextField, PasswordField, Select, MultiSelect, Radio, FilePicker, DateField, TimeField, ColorStringPicker, Microphone
-=======
-
-export Slider, NumberField, Button, CheckBox, TextField, Select, FilePicker, Radio
 
 struct Slider
     range::AbstractRange
@@ -262,7 +259,6 @@ get(select::MultiSelect) = ismissing(select.default) ? Any[] : select.default
 The optional `accept` argument can be an array of `MIME`s. The user can only select files with these MIME. If only `image/*` MIMEs are allowed, then smartphone browsers will open the camera instead of a file browser.
 
 ## Examples
-=======
 get(select::Select) = ismissing(select.default) ? first(select.options).first : select.default
 
 `@bind file_data FilePicker()`
@@ -289,8 +285,6 @@ function show(io::IO, ::MIME"text/html", filepicker::FilePicker)
 end
 
 get(select::FilePicker) = Dict("name" => "", "data" => UInt8[], "type" => "")
-=======
-get(select::FilePicker) = Dict("name" => "", "data" => [], "type" => "")
 
 """A group of radio buttons - the user can choose one of the `options`, an array of `String`s. 
 


### PR DESCRIPTION
Hallo, Fons!

I've added support for the microphone input but I'm certain it will need some additional work. With this PR, users can do:

```julia
@bind audio Microphone()
```

This returns an array that constantly updates with the audio streaming from the microphone. To visualize the data, you might do something like this:

```julia
using Plots, SampledSignals

plot(domain(SampleBuf(Array(audio), 44100)), SampleBuf(Array(audio), 44100), legend=false, ylims=(-1,1))
```

This (kind of) resolves issue #16 

Groetjes!