### PR TITLE
Add @with_terminal

### DIFF
--- a/src/Terminal.jl
+++ b/src/Terminal.jl
@@ -81,3 +81,9 @@ function with_terminal(f::Function, args...; kwargs...)
   end
 	WithTerminalOutput(spam_out, spam_err, value)
 end
+
+macro with_terminal(arg)
+    quote
+        with_terminal() do; $arg; end 
+    end
+end


### PR DESCRIPTION
I added a macro `@with_terminal` to simplify usage of with_terminal