### PR TITLE
Add CSSWidgetWrapper

### DIFF
--- a/src/CSSWidgetWrapper.jl
+++ b/src/CSSWidgetWrapper.jl
@@ -1,0 +1,55 @@
+export CSSWidgetWrapper
+
+"""
+CSS widget Wrapper
+
+Generates a div element and delegates the input event to the it. 
+In addition the widget style properties can be set via javascript.
+
+Arguments:
+widget: PlutoUI widget
+style: Dict of javascript style properties
+
+Example:
+Generate a text field with a red background and white text
+CSSWidgetWrapper(Textfield(),Dict("backgroundColor"=>"red","color"=>"white"))
+"""
+struct CSSWidgetWrapper
+    widget
+    style
+end
+
+"""
+Output the html needed to wrap a widget and apply changes via javascript.
+"""
+function show(io::IO, m::MIME"text/html", w::CSSWidgetWrapper)
+    style = ""
+    for (k,v) in w.style
+        style *= "widget.style.$k = '$v';\n"
+    end
+    
+    result = """
+        <script>
+        var container = currentScript.parentElement
+        var widget = container.children[0]
+        $style
+        
+        function setValue() {
+            container.value = widget.value
+            container.dispatchEvent(new CustomEvent('input'))
+        }        
+
+        setValue()
+        widget.addEventListener('input',setValue)
+        </script>
+    </div>
+    """
+    print(io,"<div>")
+    show(io,m,w.widget)
+    print(io,result)
+end
+
+"""
+Use the default value of the widget
+"""
+Base.get(w::CSSWidgetWrapper) = get(w.widget)

--- a/src/PlutoUI.jl
+++ b/src/PlutoUI.jl
@@ -12,6 +12,7 @@ include("./Resource.jl")
 include("./Terminal.jl")
 include("./RangeSlider.jl")
 include("./DisplayTricks.jl")
+include("./CSSWidgetWrapper.jl")
 
 @reexport module MultiCheckBoxNotebook
     include("./MultiCheckBox.jl")


### PR DESCRIPTION
This widget wraps an existing widget to add CSS styles via JavaScript.

Features:
* Redirect the value to a wrapper div element
* Add widget.style lines based on the provided dictionary

Example:
```julia
@bind text CSSWidgetWrapper(TextField(default="hi"),
	Dict("backgroundColor"=>"green","color"=>"white"))
```